### PR TITLE
Quote spawn args on Windows to fix release commit

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -34,8 +34,19 @@ function fail(msg) {
   process.exit(1);
 }
 
+function winQuote(arg) {
+  if (arg === '' || /[\s"^&|<>]/.test(arg)) {
+    return `"${String(arg).replace(/"/g, '""')}"`;
+  }
+  return arg;
+}
+
 function spawn(cmd, args, opts) {
-  return spawnSync(cmd, args, { cwd: repoRoot, shell: WIN32, ...opts });
+  return spawnSync(cmd, WIN32 ? args.map(winQuote) : args, {
+    cwd: repoRoot,
+    shell: WIN32,
+    ...opts,
+  });
 }
 
 function run(cmd, args) {


### PR DESCRIPTION
## Summary

Fixes a Windows-only failure in `scripts/release.mjs` where `git commit -m "Release X.Y.Z"` aborted with `pathspec '<version>' did not match any file(s) known to git`.

## Cause

`spawnSync` was invoked with `shell: true` on Windows. cmd.exe re-tokenizes the args, and Node does not pre-quote them, so `"Release 3.0.0"` was passed as `Release 3.0.0` and split into two tokens. Result:

```
git commit -m Release 3.0.0
              └─ msg ─┘ └─ pathspec ─┘
```

Other args happened to be safe because they contained no whitespace.

## Fix

Add a `winQuote` helper that wraps any arg containing whitespace or cmd meta-characters (`" ^ & | < >`) in double quotes, doubling embedded `"` per cmd.exe rules. Apply it only when `shell: true` is in effect (Windows).

## Test plan

- [ ] On Windows: `npm run release -- --version <next-patch>` reaches the `git commit` / `tag` / `push` steps successfully
- [ ] On macOS/Linux: behaviour unchanged (winQuote is a no-op)
- [ ] Recovery for the in-flight 3.0.0 release is independent of this PR (manual git commit + tag + push already documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)